### PR TITLE
Fix mergeable configuration

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -12,6 +12,3 @@ mergeable:
       must_exclude: 
         regex: "wip"
         message: "This PR is work in progress."
-    project: "EMS"
-  issues:
-    project: "EMS"


### PR DESCRIPTION
We use organization wide projects instead. Mergeable cannot figure out to use that; complains that projects are disabled for this repo, which indeed it is.